### PR TITLE
Enables producer level metrics in staging

### DIFF
--- a/entur/deployment-config/helm/otp2/env/values-kub-ent-jp-tst.yaml
+++ b/entur/deployment-config/helm/otp2/env/values-kub-ent-jp-tst.yaml
@@ -65,7 +65,7 @@ configuration:
     subscriptionProjectName: ent-otp2-tst
     pubsubTopicName: xml.estimated_timetables
     dataInitializationUrl: http://realtime-cache.tst.entur.internal/et
-    producerMetrics: false
+    producerMetrics: true
   siriSXUpdater: http://realtime-cache.tst.entur.internal/sx
   transferConstraints: true
   vehicleRentalServiceDirectory:


### PR DESCRIPTION
This was enabled in dev in https://github.com/entur/otp-deployment-config/commit/da1c7f81cfd81a45491ad1a362a6d7c9a9defd5c

The flag was added in https://github.com/opentripplanner/OpenTripPlanner/pull/6199