### PR TITLE
Enables producerMetrics in OTP prod.

### DIFF
--- a/entur/deployment-config/helm/otp2/env/values-kub-ent-jp-prd.yaml
+++ b/entur/deployment-config/helm/otp2/env/values-kub-ent-jp-prd.yaml
@@ -65,7 +65,7 @@ configuration:
     subscriptionProjectName: ent-otp2-prd
     pubsubTopicName: xml.estimated_timetables
     dataInitializationUrl: http://realtime-cache.prd.entur.internal/et
-    producerMetrics: false
+    producerMetrics: true
   siriSXUpdater: http://realtime-cache.prd.entur.internal/sx
   transferConstraints: true
   vehicleRentalServiceDirectory:


### PR DESCRIPTION
This was enabled in 
- staging in https://github.com/entur/OpenTripPlanner/pull/12
- dev in https://github.com/entur/otp-deployment-config/commit/da1c7f81cfd81a45491ad1a362a6d7c9a9defd5c

The flag was added in https://github.com/opentripplanner/OpenTripPlanner/pull/6199