### PR TITLE
Enables carpooling in dev.

### DIFF
--- a/entur/deployment-config/helm/otp2/env/values-kub-ent-jp-dev.yaml
+++ b/entur/deployment-config/helm/otp2/env/values-kub-ent-jp-dev.yaml
@@ -51,7 +51,7 @@ proxy:
 # Realtime-updaters use internal service instead of external (Apigee) to avoid inexplicable timeouts
 configuration:
   apiProcessingTimeout: "7s"
-  carpooling: false
+  carpooling: true
   emission: true
   empiricalDelay: true
   flexRouting: true
@@ -61,6 +61,7 @@ configuration:
   optimizeTransfers: true
   parallelRouting: false
   siriETUpdater: http://anshar.dev.entur.internal/anshar/services
+  siriETCarpoolingUpdater: http://subula.dev.entur.internal/siri/et
   siriETPubsubUpdater:
     enabled: true
     topicProjectName: ent-anshar-dev

--- a/entur/deployment-config/helm/otp2/templates/configmap.yaml
+++ b/entur/deployment-config/helm/otp2/templates/configmap.yaml
@@ -215,11 +215,10 @@ data:
           {
             "type": "siri-et-carpooling-updater",
             "frequency": "20s",
-            "url":  "https://api.dev.entur.io/realtime/v1/services/ENT?SIRI_VERSION=2.1",
+            "url":  "{{ .Values.configuration.siriETCarpoolingUpdater }}",
             "feedId": "EN",
             "timeout": "10s",
-            "blockReadinessUntilInitialized": true,
-            "fuzzyTripMatching": true
+            "blockReadinessUntilInitialized": true
           },
      {{- end }}
     {{- if .Values.configuration.siriETPubsubUpdater.enabled }}


### PR DESCRIPTION
Enables carpooling in dev.

The siriETCarpoolingUpdater points to http://subula.dev.entur.internal/siri/et which is an Entur internal endpoint for carpooling SIRI ET messages only. The subula service (https://github.com/entur/subula) contains only carpooling messages and currently returns all messages for every request to the siri/et endpoint. We intend this to be the case only for the short term, and we have plans for changing this in the near future. The siri-et-carpooling-updater updater type was merged into dev-2.x as a part of https://github.com/opentripplanner/OpenTripPlanner/pull/6791