### PR TITLE
Add non-regression tests for snapshot mutation patterns

### DIFF
--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/cancellation/CancelAfterPatternChangeTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/moduletests/cancellation/CancelAfterPatternChangeTest.java
@@ -1,0 +1,90 @@
+package org.opentripplanner.updater.trip.gtfs.moduletests.cancellation;
+
+import static com.google.transit.realtime.GtfsRealtime.TripDescriptor.ScheduleRelationship.CANCELED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.opentripplanner.transit.model._data.FeedScopedIdForTestFactory.id;
+import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertSuccess;
+import static org.opentripplanner.updater.trip.UpdateIncrementality.DIFFERENTIAL;
+
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.transit.model._data.TransitTestEnvironment;
+import org.opentripplanner.transit.model._data.TransitTestEnvironmentBuilder;
+import org.opentripplanner.transit.model._data.TripInput;
+import org.opentripplanner.transit.model.site.RegularStop;
+import org.opentripplanner.transit.model.timetable.RealTimeState;
+import org.opentripplanner.updater.trip.GtfsRtTestHelper;
+import org.opentripplanner.updater.trip.RealtimeTestConstants;
+
+/**
+ * Test canceling a trip after a pattern change (skipped stop). This exercises the revert path
+ * where a modified pattern must be cleaned up before the cancellation is applied to the
+ * scheduled pattern.
+ */
+class CancelAfterPatternChangeTest implements RealtimeTestConstants {
+
+  private final TransitTestEnvironmentBuilder ENV_BUILDER = TransitTestEnvironment.of();
+  private final RegularStop STOP_A = ENV_BUILDER.stop(STOP_A_ID);
+  private final RegularStop STOP_B = ENV_BUILDER.stop(STOP_B_ID);
+  private final RegularStop STOP_C = ENV_BUILDER.stop(STOP_C_ID);
+
+  private final TripInput TRIP_INPUT = TripInput.of(TRIP_1_ID)
+    .addStop(STOP_A, "0:01:00", "0:01:01")
+    .addStop(STOP_B, "0:01:10", "0:01:11")
+    .addStop(STOP_C, "0:01:20", "0:01:21");
+
+  /**
+   * First skip a stop (creating a modified pattern), then cancel the trip. The cancellation
+   * should revert the pattern change and mark the trip as CANCELED on the scheduled pattern.
+   */
+  @Test
+  void cancelScheduledTripAfterSkippedStop() {
+    var env = ENV_BUILDER.addTrip(TRIP_INPUT).build();
+    var rt = GtfsRtTestHelper.of(env);
+
+    // Step 1: Skip stop B — creates a modified pattern
+    var skipUpdate = rt
+      .tripUpdateScheduled(TRIP_1_ID)
+      .addDelayedStopTime(0, 0)
+      .addSkippedStop(1)
+      .addDelayedStopTime(2, 90)
+      .build();
+
+    assertSuccess(rt.applyTripUpdate(skipUpdate, DIFFERENTIAL));
+
+    // Verify the modified pattern was created
+    var snapshot = env.timetableSnapshot();
+    assertNotNull(
+      snapshot.getNewTripPatternForModifiedTrip(id(TRIP_1_ID), env.defaultServiceDate()),
+      "A modified trip pattern should exist after skipping a stop"
+    );
+
+    assertEquals(
+      "UPDATED | A 0:01 0:01:01 | B [C] 0:01:52 0:01:58 | C 0:02:50 0:02:51",
+      env.tripData(TRIP_1_ID).showTimetable()
+    );
+
+    // Step 2: Cancel the trip
+    var cancelUpdate = rt.tripUpdate(TRIP_1_ID, CANCELED).build();
+    assertSuccess(rt.applyTripUpdate(cancelUpdate, DIFFERENTIAL));
+
+    // Verify the modified pattern is cleaned up
+    snapshot = env.timetableSnapshot();
+    assertNull(
+      snapshot.getNewTripPatternForModifiedTrip(id(TRIP_1_ID), env.defaultServiceDate()),
+      "Modified trip pattern should be removed after cancellation"
+    );
+
+    // Trip should be CANCELED on the scheduled pattern
+    var tripData = env.tripData(TRIP_1_ID);
+    assertEquals(RealTimeState.CANCELED, tripData.realTimeState());
+    assertTrue(tripData.tripTimes().isCanceledOrDeleted());
+
+    assertEquals(
+      "CANCELED | A 0:01 0:01:01 | B 0:01:10 0:01:11 | C 0:01:20 0:01:21",
+      tripData.showTimetable()
+    );
+  }
+}

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/extracall/ExtraCallTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/moduletests/extracall/ExtraCallTest.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.updater.trip.siri.moduletests.extracall;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertFailure;
 import static org.opentripplanner.updater.spi.UpdateResultAssertions.assertSuccess;
@@ -50,6 +51,10 @@ class ExtraCallTest implements RealtimeTestConstants {
     );
   }
 
+  /**
+   * Apply the same extra call update twice (identical message). Verifies idempotency: the trip
+   * times and the MODIFIED pattern are unchanged after the second application.
+   */
   @Test
   void testExtraCallMultipleTimes() {
     var env = ENV_BUILDER.addTrip(TRIP_1_INPUT).build();
@@ -64,6 +69,9 @@ class ExtraCallTest implements RealtimeTestConstants {
       "MODIFIED | A [R] 0:00:15 0:00:15 | D [EC] 0:00:20 0:00:25 | B 0:00:33 0:00:33",
       env.tripData(TRIP_1_ID).showTimetable()
     );
+    var patterns = env.raptorData().summarizePatterns();
+    assertThat(patterns).hasSize(1);
+    assertThat(patterns.stream().findFirst().get()).endsWith("[MODIFIED]");
   }
 
   @Test
@@ -89,6 +97,101 @@ class ExtraCallTest implements RealtimeTestConstants {
       "CANCELED | A 0:00:10 0:00:11 | B 0:00:20 0:00:21",
       env.tripData(TRIP_1_ID).showTimetable()
     );
+  }
+
+  /**
+   * Add an extra call (A → D(extra) → B), then send a second update with the same extra call
+   * but different times. Unlike {@link #testExtraCallMultipleTimes()} which replays an identical
+   * message, this test verifies that updated times are actually applied while preserving the
+   * extra call and the MODIFIED pattern.
+   */
+  @Test
+  void testExtraCallThenUpdateTimesKeepsExtraCall() {
+    var env = ENV_BUILDER.addTrip(TRIP_1_INPUT).build();
+    var siri = SiriTestHelper.of(env);
+
+    // Step 1: Add extra call D between A and B
+    var extraCallUpdate = updateWithExtraCall(siri);
+    assertSuccess(siri.applyEstimatedTimetable(extraCallUpdate));
+
+    assertEquals(
+      "MODIFIED | A [R] 0:00:15 0:00:15 | D [EC] 0:00:20 0:00:25 | B 0:00:33 0:00:33",
+      env.tripData(TRIP_1_ID).showTimetable()
+    );
+    assertThat(env.raptorData().summarizePatterns()).containsExactly(
+      "F:route-id::001:RT[MODIFIED]"
+    );
+
+    // Step 2: Send update with same extra call but different times
+    var updatedTimes = siri
+      .etBuilder()
+      .withDatedVehicleJourneyRef(TRIP_1_ID)
+      .withLineRef(ROUTE_ID)
+      .withRecordedCalls(builder -> builder.call(STOP_A).departAimedActual("00:00:11", "00:00:16"))
+      .withEstimatedCalls(builder ->
+        builder
+          .call(STOP_D)
+          .withIsExtraCall(true)
+          .arriveAimedExpected("00:00:18", "00:00:22")
+          .departAimedExpected("00:00:19", "00:00:27")
+          .call(STOP_B)
+          .arriveAimedExpected("00:00:20", "00:00:35")
+      )
+      .buildEstimatedTimetableDeliveries();
+
+    var result = siri.applyEstimatedTimetable(updatedTimes);
+    assertSuccess(result);
+
+    // Extra call D should still be present with updated times
+    assertEquals(
+      "MODIFIED | A [R] 0:00:16 0:00:16 | D [EC] 0:00:22 0:00:27 | B 0:00:35 0:00:35",
+      env.tripData(TRIP_1_ID).showTimetable()
+    );
+    var patterns = env.raptorData().summarizePatterns();
+    assertThat(patterns).hasSize(1);
+    assertThat(patterns.stream().findFirst().get()).endsWith("[MODIFIED]");
+  }
+
+  /**
+   * Add an extra call (A → D(extra) → B), then send a regular update without the extra call
+   * (A → B with updated times). The trip should revert to the scheduled pattern.
+   */
+  @Test
+  void testExtraCallThenRevertToOriginalStops() {
+    var env = ENV_BUILDER.addTrip(TRIP_1_INPUT).build();
+    var siri = SiriTestHelper.of(env);
+
+    // Step 1: Add extra call D between A and B
+    var extraCallUpdate = updateWithExtraCall(siri);
+    assertSuccess(siri.applyEstimatedTimetable(extraCallUpdate));
+
+    assertEquals(
+      "MODIFIED | A [R] 0:00:15 0:00:15 | D [EC] 0:00:20 0:00:25 | B 0:00:33 0:00:33",
+      env.tripData(TRIP_1_ID).showTimetable()
+    );
+    assertThat(env.raptorData().summarizePatterns()).containsExactly(
+      "F:route-id::001:RT[MODIFIED]"
+    );
+
+    // Step 2: Send regular update without extra call — just A → B with updated times
+    var revert = siri
+      .etBuilder()
+      .withDatedVehicleJourneyRef(TRIP_1_ID)
+      .withRecordedCalls(builder -> builder.call(STOP_A).departAimedActual("00:00:11", "00:00:16"))
+      .withEstimatedCalls(builder ->
+        builder.call(STOP_B).arriveAimedExpected("00:00:20", "00:00:30")
+      )
+      .buildEstimatedTimetableDeliveries();
+
+    var result = siri.applyEstimatedTimetable(revert);
+    assertSuccess(result);
+
+    // Trip should revert to the scheduled pattern with UPDATED state
+    assertEquals(
+      "UPDATED | A [R] 0:00:16 0:00:16 | B 0:00:30 0:00:30",
+      env.tripData(TRIP_1_ID).showTimetable()
+    );
+    assertThat(env.raptorData().summarizePatterns()).containsExactly("F:Pattern1[UPDATED]");
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Add tests that exercise the revert→delete→apply cycle for pattern changes, establishing a non-regression baseline before centralizing snapshot mutations in `TimetableSnapshotManager`
- GTFS-RT: cancel a trip after a skipped stop created a modified pattern (`CancelAfterPatternChangeTest`)
- SIRI: extra call then update times preserving the extra call, and extra call then revert to original stops (`ExtraCallTest`)

## Test plan
- [x] All 9 affected tests pass
- [x] Full trip updater suite (257 tests) passes with no regressions