### PR TITLE
Remove Google Cloud SDK from Docker image, use OTP native GCS

### DIFF
--- a/entur/deployment-config/Dockerfile
+++ b/entur/deployment-config/Dockerfile
@@ -9,16 +9,9 @@ RUN mkdir -p /code/otpdata/norway
 WORKDIR /code
 
 RUN apt-get -y update && apt-get -y upgrade && apt-get install -y \
-    apt-transport-https \
     ca-certificates \
-    gnupg \
-    curl
-
-# From https://cloud.google.com/sdk/docs/install
-RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
-    && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg \
-    && apt-get update -y \
-    && apt-get install -y google-cloud-cli
+    curl \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY --chmod=444 otp-shaded/target/otp-shaded-*.jar /code/otp-shaded.jar
 

--- a/entur/deployment-config/docker/docker-entrypoint.sh
+++ b/entur/deployment-config/docker/docker-entrypoint.sh
@@ -1,44 +1,54 @@
 #!/bin/bash
 
-: ${GRAPH_FILE_TARGET_PATH="/code/otpdata/norway/graph.obj"}
-: ${FILE_TMP_PATH="/tmp/graph_obj_from_gcs"}
-: ${FILE_TMP_GRAPH_FILE_LIST="/tmp/list_graph_files.txt"}
-# Notice ending slash here, it is correct
+set -euo pipefail
+
 : ${MARDUK_GCP_BASE="gs://marduk/"}
 : ${GRAPH_POINTER_FILE="current-otp2"}
 
-echo "GRAPH_FILE_TARGET_PATH: $GRAPH_FILE_TARGET_PATH"
-serializationVersionId=$(java -jar otp-shaded.jar --serializationVersionId)
-echo serializationVersionId: $serializationVersionId
-gcloud storage cat ${MARDUK_GCP_BASE}netex-otp2/${serializationVersionId}/${GRAPH_POINTER_FILE} 2> ${FILE_TMP_GRAPH_FILE_LIST} 1>${FILE_TMP_GRAPH_FILE_LIST}
-   if grep -q 'ERROR' ${FILE_TMP_GRAPH_FILE_LIST}; then
-      echo "RC Graph with serialId not found " $serializationVersionId
-      echo "Use main graph file"
-      FILENAME=$(gcloud storage cat ${MARDUK_GCP_BASE}${GRAPH_POINTER_FILE})
-   else
-      echo "Found RC graph use this one"
-      FILENAME=$(gcloud storage cat ${MARDUK_GCP_BASE}netex-otp2/${serializationVersionId}/${GRAPH_POINTER_FILE})
+# Extract bucket name from gs:// URI
+# e.g. "gs://ror-otp-graphs-gcp2-production/" -> "ror-otp-graphs-gcp2-production"
+BUCKET="${MARDUK_GCP_BASE#gs://}"
+BUCKET="${BUCKET%/}"
+echo "Bucket: $BUCKET"
 
-   fi
-   echo "FILENAME: " $FILENAME
-rm ${FILE_TMP_GRAPH_FILE_LIST}
+# Get OTP serialization version ID
+SER_ID=$(java -jar otp-shaded.jar --serializationVersionId)
+echo "Serialization version ID: $SER_ID"
 
-DOWNLOAD="${MARDUK_GCP_BASE}${FILENAME}"
-echo "Downloading $DOWNLOAD"
-gcloud storage --no-user-output-enabled cp $DOWNLOAD $FILE_TMP_PATH
+# Get GKE Workload Identity OAuth2 token from metadata server
+TOKEN=$(curl -sf -H "Metadata-Flavor: Google" \
+  "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token" \
+  | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
 
-# Testing exists and has a size greater than zero
-if [ -s $FILE_TMP_PATH ] ;
-then
-  echo "Overwriting $GRAPH_FILE_TARGET_PATH"
-  mv $FILE_TMP_PATH $GRAPH_FILE_TARGET_PATH
+if [ -z "$TOKEN" ]; then
+  echo "ERROR: Failed to get OAuth2 token from metadata server"
+  exit 1
+fi
+
+# Read a GCS object's content via the JSON API
+gcs_read() {
+  local object="$1"
+  local encoded
+  encoded=$(printf '%s' "$object" | sed 's|/|%2F|g')
+  curl -sf -H "Authorization: Bearer $TOKEN" \
+    "https://storage.googleapis.com/storage/v1/b/${BUCKET}/o/${encoded}?alt=media"
+}
+
+# Read graph pointer file for this serialization version.
+# If not found, the graph may still be building — sleep 5m to avoid
+# CrashLoopBackOff and give the graph builder time to finish.
+POINTER="netex-otp2/${SER_ID}/${GRAPH_POINTER_FILE}"
+if FILENAME=$(gcs_read "$POINTER"); then
+  echo "Found graph pointer: $FILENAME"
 else
-  echo "** WARNING: Downloaded file ($FILE_TMP_PATH) is empty or not present**"
-  echo "** Not overwriting $GRAPH_FILE_TARGET_PATH**"
-  wget -q --header 'Content-Type: application/json' --post-data='{"source":"otp", "message":":no_entry: Downloaded file is empty or not present. This makes OTP fail! Please check logs"}' http://hubot/hubot/say/
-  echo "Now sleeping 5m in the hope that this will be manually resolved in the mean time, and then restarting."
+  echo "** WARNING: No graph pointer file found for serialization ID $SER_ID **"
+  echo "** The graph may still be building. Sleeping 5m before retrying. **"
   sleep 5m
   exit 1
 fi
+
+# Export GRAPH_URI so OTP substitutes ${GRAPH_URI} in build-config.json
+export GRAPH_URI="gs://${BUCKET}/${FILENAME}"
+echo "Graph URI: $GRAPH_URI"
 
 exec "$@"

--- a/entur/deployment-config/helm/otp2/templates/deployment.yaml
+++ b/entur/deployment-config/helm/otp2/templates/deployment.yaml
@@ -184,6 +184,9 @@ spec:
         - mountPath: /etc/otp2/logback.xml
           name: logback-config-volume
           subPath: logback.xml
+        - name: build-config-volume
+          mountPath: /code/otpdata/norway/build-config.json
+          subPath: build-config.json
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -207,4 +210,8 @@ spec:
           defaultMode: 420
           name: otp2-logback-config
         name: logback-config-volume
+      - configMap:
+          defaultMode: 420
+          name: otp2-build-config
+        name: build-config-volume
 {{- end }}

--- a/entur/deployment-config/helm/otp2/templates/nordic/deployment.yaml
+++ b/entur/deployment-config/helm/otp2/templates/nordic/deployment.yaml
@@ -143,6 +143,9 @@ spec:
         - mountPath: /etc/otp2/logback.xml
           name: logback-config-volume
           subPath: logback.xml
+        - name: build-config-volume
+          mountPath: /code/otpdata/norway/build-config.json
+          subPath: build-config.json
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -171,4 +174,8 @@ spec:
           defaultMode: 420
           name: otp2nordic-logback-config
         name: logback-config-volume
+      - configMap:
+          defaultMode: 420
+          name: otp2nordic-build-config
+        name: build-config-volume
 {{- end }}

--- a/entur/deployment-config/helm/otp2/templates/nordic/otp2-build-configmap.yaml
+++ b/entur/deployment-config/helm/otp2/templates/nordic/otp2-build-configmap.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.nordicJourneyPlanner.enabled }}
+apiVersion: v1
+data:
+  build-config.json: |+
+   {
+      "graph": "${GRAPH_URI}"
+   }
+kind: ConfigMap
+metadata:
+  name: otp2nordic-build-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "common.nordic.labels" . | indent 4 }}
+{{- end }}

--- a/entur/deployment-config/helm/otp2/templates/nordic/otp2-feature-configmap.yaml
+++ b/entur/deployment-config/helm/otp2/templates/nordic/otp2-feature-configmap.yaml
@@ -10,7 +10,8 @@ data:
         "OptimizeTransfers": {{ .Values.configuration.optimizeTransfers }},
         "TransferConstraints": {{ .Values.configuration.transferConstraints }},
         "ParallelRouting": {{ .Values.configuration.parallelRouting }},
-        "ReportApi" : true
+        "ReportApi" : true,
+        "GoogleCloudStorage": true
       }
    }
 kind: ConfigMap

--- a/entur/deployment-config/helm/otp2/templates/otp2-build-configmap.yaml
+++ b/entur/deployment-config/helm/otp2/templates/otp2-build-configmap.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.journeyPlanner.enabled }}
+apiVersion: v1
+data:
+  build-config.json: |+
+   {
+      "graph": "${GRAPH_URI}"
+   }
+kind: ConfigMap
+metadata:
+  name: otp2-build-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "common.labels" . | indent 4 }}
+{{- end }}

--- a/entur/deployment-config/helm/otp2/templates/otp2-feature-configmap.yaml
+++ b/entur/deployment-config/helm/otp2/templates/otp2-feature-configmap.yaml
@@ -18,7 +18,8 @@ data:
         "Sorlandsbanen" : {{ .Values.configuration.sorlandsbanen }},
         "TransferConstraints": {{ .Values.configuration.transferConstraints }},
         "CarPooling": {{ .Values.configuration.carpooling }},
-        "HttpResponseTimeMetrics": true
+        "HttpResponseTimeMetrics": true,
+        "GoogleCloudStorage": true
       }
    }
 kind: ConfigMap


### PR DESCRIPTION
## Summary

Remove `google-cloud-cli` (~150 MB) from the OTP Docker image by switching to OTP's built-in Google Cloud Storage support for graph loading at pod startup.

## Motivation

The OTP Docker image is ~588 MB, of which ~150 MB (25%) is the `google-cloud-cli` package. It is installed solely for 3 `gcloud storage` commands in `docker-entrypoint.sh` that download the transit graph from GCS. The graph builder CronJob already uses OTP's native GCS support (`GoogleCloudStorage: true` + `gs://` URIs in `build-config.json`), proving the pattern works in this GKE environment.

Removing `gcloud` saves ~150 MB, improves image pull times, and makes GKE Image Streaming more effective.

## How it works

**Before:** The entrypoint used `gcloud storage cat` to resolve the pointer file and `gcloud storage cp` to download the ~1.7 GB graph to local disk, then OTP loaded it from the filesystem.

**After:**
1. The entrypoint resolves the graph pointer file via `curl` + GCS JSON API (using a Workload Identity token from the GKE metadata server)
2. It exports `GRAPH_URI=gs://bucket/resolved-graph-path`
3. A new `build-config.json` ConfigMap contains `"graph": "${GRAPH_URI}"`
4. OTP substitutes the environment variable (same mechanism as `${HOSTNAME}` in `router-config.json`) and streams the graph directly from GCS using its built-in Java client

This eliminates the intermediate download to local disk — OTP deserializes the graph directly from the GCS stream.

## Changes

| File | Change |
|---|---|
| `Dockerfile` | Remove `google-cloud-cli` installation, simplify apt-get to `ca-certificates` + `curl` |
| `docker-entrypoint.sh` | Rewrite: resolve pointer via `curl` + GCS JSON API, export `GRAPH_URI` |
| `otp2-feature-configmap.yaml` | Add `"GoogleCloudStorage": true` |
| `nordic/otp2-feature-configmap.yaml` | Add `"GoogleCloudStorage": true` |
| `otp2-build-configmap.yaml` **(new)** | `build-config.json` with `"graph": "${GRAPH_URI}"` |
| `nordic/otp2-build-configmap.yaml` **(new)** | Same for Nordic |
| `deployment.yaml` | Mount `build-config.json` ConfigMap |
| `nordic/deployment.yaml` | Mount `build-config.json` ConfigMap |

## Error handling

If the graph pointer file is not found (e.g. the graph is still being built after an OTP version bump), the entrypoint sleeps 5 minutes before exiting. This avoids CrashLoopBackOff exponential backoff and gives the graph builder time to finish.

## Verification

Tested locally by starting OTP with a `build-config.json` containing `"graph": "${GRAPH_URI}"` and `GoogleCloudStorage: true`. OTP successfully resolved the env var, connected to the staging GCS bucket, and streamed the graph file (failed only on serialization version mismatch, confirming the GCS code path works):

```
Summarizing 'build-config.json': { "graph" : "gs://ror-otp-graphs-gcp2-test/netex-otp2/EN-0171/..." }
Google Cloud Store Repository enabled - GS resources detected.
Data source location(s): Google Cloud Storage, HTTPS, /tmp/otp-gcs-test
🌐 netex-otp2/EN-0171/...  gs://ror-otp-graphs-gcp2-test  2.4 GB
Reading graph from 'gs://ror-otp-graphs-gcp2-test/netex-otp2/EN-0171/...'
```
