### PR TITLE
Update GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -27,14 +27,14 @@ jobs:
     timeout-minutes: 20
     steps:
       # Starting in v2.2 checkout action fetches all tags when fetch-depth=0, for auto-versioning.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       # nodejs is needed because the dynamic download of it via the prettier maven plugin often
       # times out
       # Example: https://github.com/opentripplanner/OpenTripPlanner/actions/runs/4490450225/jobs/7897533439
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 18
 
@@ -58,7 +58,7 @@ jobs:
 
       - name: Send coverage data to codecov.io
         if: github.repository_owner == 'opentripplanner' && github.event_name != 'merge_group'
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
@@ -81,7 +81,7 @@ jobs:
     timeout-minutes: 20
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
@@ -107,7 +107,7 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         # this is necessary so that the correct credentials are put into the git configuration
         # when we push to dev-2.x and push the HTML to the git repo
         if: github.event_name == 'push' && (github.ref == 'refs/heads/dev-2.x' || github.ref == 'refs/heads/master')
@@ -117,7 +117,7 @@ jobs:
           # was modified last
           fetch-depth: 1000
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         # for a simple PR where we don't push, we don't need any credentials
         if: github.event_name != 'push'
 
@@ -129,7 +129,7 @@ jobs:
         if: github.event_name != 'push'
         run: mkdocs build
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
 
@@ -190,8 +190,8 @@ jobs:
     if: github.repository_owner == 'opentripplanner'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
       - name: Run code generator
@@ -215,7 +215,7 @@ jobs:
       - build-windows
       - build-linux
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Set up JDK 25
@@ -224,7 +224,7 @@ jobs:
           java-version: 25
           distribution: temurin
           cache: maven
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 18
       - name: Build container image with Jib, push to Dockerhub

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -36,7 +36,7 @@ jobs:
       # Example: https://github.com/opentripplanner/OpenTripPlanner/actions/runs/4490450225/jobs/7897533439
       - uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 24
 
       # Java setup step completes very fast, no need to run in a preconfigured docker container
       - name: Set up JDK 25
@@ -227,7 +227,7 @@ jobs:
           cache: maven
       - uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 24
       - name: Build container image with Jib, push to Dockerhub
         env:
           CONTAINER_REPO: docker.io/opentripplanner/opentripplanner

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -65,11 +65,12 @@ jobs:
 
       - name: Upload test results to Codecov
         # always upload test results, even when failed
-        if: ${{ !cancelled() }} && github.event_name != 'merge_group'
-        uses: codecov/test-results-action@v1
+        if: ${{ !cancelled() && github.event_name != 'merge_group' }}
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: "*TEST-*.xml"
+          report_type: "test_results"
 
       - name: Deploy to Github Package Registry
         if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev-2.x')
@@ -91,7 +92,7 @@ jobs:
       # on windows there are frequent failures caused by page files being too small
       # https://github.com/actions/virtual-environments/issues/785
       - name: Configure Windows Pagefile
-        uses: al-cheb/configure-pagefile-action@v1.4
+        uses: al-cheb/configure-pagefile-action@v1.5
       - name: Run tests
         run: mvn test -P prettierSkip,checkstyleSkip
 

--- a/.github/workflows/close_stale_pr_and_issues.yml
+++ b/.github/workflows/close_stale_pr_and_issues.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.repository_owner == 'opentripplanner'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@v10.3.0
         id: stale
         with:
           stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 30 days'

--- a/.github/workflows/close_stale_pr_and_issues.yml
+++ b/.github/workflows/close_stale_pr_and_issues.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.repository_owner == 'opentripplanner'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v6.0.1
+      - uses: actions/stale@v10
         id: stale
         with:
           stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 30 days'

--- a/.github/workflows/debug-client.yml
+++ b/.github/workflows/debug-client.yml
@@ -43,7 +43,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Set version
         run: echo "VERSION=`date +%Y/%m/%Y-%m-%dT%H:%M`" >> $GITHUB_ENV

--- a/.github/workflows/debug-client.yml
+++ b/.github/workflows/debug-client.yml
@@ -31,17 +31,17 @@ jobs:
     steps:
       # this is necessary so that the correct credentials are put into the git configuration
       # when we push to dev-2.x and push the compiled output to the git repo
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         with:
           token: ${{ secrets.CHANGELOG_TOKEN }}
           fetch-depth: 0
 
       # for a simple PR where we don't push, we don't need any credentials
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
 

--- a/.github/workflows/entur-a-otp-release.yml
+++ b/.github/workflows/entur-a-otp-release.yml
@@ -45,19 +45,19 @@ jobs:
       ser_ver_id: ${{ steps.set_ser_ver_id.outputs.ser_ver_id }}
     steps:
       - name: Checkout entur/OpenTripPlanner
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: '${{ secrets.ENTUR_OTP_CI_BUILD }}'
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.13'
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           java-version: 25
           distribution: temurin
       - name: Cache Maven dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/entur-b-docker-build.yml
+++ b/.github/workflows/entur-b-docker-build.yml
@@ -11,15 +11,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           java-version: 25
           distribution: temurin
       - name: Cache Maven dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -29,7 +29,7 @@ jobs:
             ${{ runner.os }}-
       - name: Run maven build
         run: mvn verify -Dps -DskipTests -Dcheckstyle.skip
-      - uses: actions/upload-artifact@v4.4.0
+      - uses: actions/upload-artifact@v7
         with:
           path: otp-shaded/target/otp-shaded-*.jar
   docker-build:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.repository_owner == 'opentripplanner' && contains( github.event.pull_request.labels.*.name, '+Integration Test' )
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up JDK 25
         uses: actions/setup-java@v5

--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -66,7 +66,7 @@ jobs:
             profile: extended
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: matrix.profile == 'core' || github.ref == 'refs/heads/dev-2.x'
         with:
           fetch-depth: 0
@@ -108,14 +108,14 @@ jobs:
 
       - name: Archive travel results file
         if: matrix.profile == 'core' || github.ref == 'refs/heads/dev-2.x'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.location }}-travelSearch-results.csv
           path: test/performance/${{ matrix.location }}/travelSearch-results-md.csv
 
       - name: Archive Flight Recorder instrumentation file
         if: matrix.profile == 'core' || github.ref == 'refs/heads/dev-2.x'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.location }}-flight-recorder
           path: ${{ matrix.location }}-speed-test.jfr

--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Set up Maven
         if: matrix.profile == 'core' || github.ref == 'refs/heads/dev-2.x'
-        uses: stCarolas/setup-maven@v5
+        uses: stCarolas/setup-maven@v5.1
         with:
           maven-version: 3.9.12
 

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.CHANGELOG_TOKEN }}
 
@@ -63,7 +63,7 @@ jobs:
           git config --global user.email 'serialization-version-bot@opentripplanner.org'
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.CHANGELOG_TOKEN }}
 

--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Install GraphQL Inspector
         run: |
@@ -50,7 +50,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Install GraphQL Inspector
         run: |

--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -17,13 +17,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 'Fetch dev.2.x for diffing'
         run: |
           git fetch origin dev-2.x --depth 1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
 
@@ -42,13 +42,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 'Fetch dev.2.x for diffing'
         run: |
           git fetch origin dev-2.x --depth 1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
 


### PR DESCRIPTION
Updates the GitHub Actions used in `main_config` workflows to their current major versions, aligning the action **versions** with what upstream `dev-2.x` already uses, while preserving Entur-specific workflow content.

## Action version bumps
| Action | Was | Now |
|---|---|---|
| actions/checkout | v4 / v5 | v6 |
| actions/setup-node | v4 | v6 |
| actions/setup-java | v4 (entur workflows) | v5 |
| actions/setup-python | v5 | v6 |
| actions/cache | v4 | v5 |
| actions/upload-artifact | v4 / v4.4.0 | v7 |
| actions/stale | v6.0.1 | v10.3.0 |
| codecov/codecov-action | v4 | v7 |
| al-cheb/configure-pagefile-action | v1.4 | v1.5 |
| stCarolas/setup-maven | v5 | v5.1 |

Also replaces the now-deprecated `codecov/test-results-action@v1` step with upstream's `codecov/codecov-action@v7` (`report_type: "test_results"`), which additionally fixes a malformed `if:` expression (`${{ !cancelled() }} && …` → `${{ !cancelled() && … }}`).

Bumping the action major versions also moves every JS-based action onto the Node 24 **runtime**, clearing the "Node16/Node20 is deprecated" runner warnings.

## node-version (build toolchain)
Separately from the action runtime, the `node-version:` inputs (Node used for prettier, mkdocs, the GraphQL code generator, the Jib docker step, the debug-client build, and GraphQL Inspector) are bumped to retire EOL Node 18:
- **Shared workflows** match upstream `dev-2.x`: prettier 24, mkdocs 20, code-gen 22, debug-client 24.
- **Entur-specific steps** use Node 24: the Jib docker `setup-node` step in `cibuild.yml`, and the `schema-validation.yml` GraphQL Inspector steps.

## Shared vs Entur-only workflows
Most of these workflows are inherited from upstream OTP, and `dev-2.x` already runs these same action versions — so the shared files were simply lagging behind. This PR brings their action versions in line with upstream.

- **Shared with upstream** (also maintained via `dev-2.x` merges): `cibuild`, `close_stale_pr_and_issues`, `debug-client`, `integration-test`, `performance-test`, `post-merge`.
- **Entur-only** (no upstream source — only updated here): `entur-a-otp-release`, `entur-b-docker-build`, `schema-validation`.

## Entur-specific content preserved (not a wholesale upstream copy)
Apart from the node-version bumps above, this PR changes **only `uses:` action versions** (plus the codecov-results step modernization). The deliberate Entur differences from upstream are intentionally kept:
- `cibuild.yml`: the extra `setup-node` step before the Jib docker build that upstream does not have.
- `performance-test.yml`: omits `-XX:+UseCompactObjectHeaders` (graph build + `MAVEN_OPTS`); keeps the Hamburg-disabled matrix comment.

## Left untouched
- `entur/gha-docker/...@v1` — current.