### PR TITLE
Fix release conflict: revert action bumps in shared workflows

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -27,16 +27,16 @@ jobs:
     timeout-minutes: 20
     steps:
       # Starting in v2.2 checkout action fetches all tags when fetch-depth=0, for auto-versioning.
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       # nodejs is needed because the dynamic download of it via the prettier maven plugin often
       # times out
       # Example: https://github.com/opentripplanner/OpenTripPlanner/actions/runs/4490450225/jobs/7897533439
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 18
 
       # Java setup step completes very fast, no need to run in a preconfigured docker container
       - name: Set up JDK 25
@@ -58,19 +58,18 @@ jobs:
 
       - name: Send coverage data to codecov.io
         if: github.repository_owner == 'opentripplanner' && github.event_name != 'merge_group'
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
 
       - name: Upload test results to Codecov
         # always upload test results, even when failed
-        if: ${{ !cancelled() && github.event_name != 'merge_group' }}
-        uses: codecov/codecov-action@v7
+        if: ${{ !cancelled() }} && github.event_name != 'merge_group'
+        uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: "*TEST-*.xml"
-          report_type: "test_results"
 
       - name: Deploy to Github Package Registry
         if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev-2.x')
@@ -82,7 +81,7 @@ jobs:
     timeout-minutes: 20
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
@@ -92,7 +91,7 @@ jobs:
       # on windows there are frequent failures caused by page files being too small
       # https://github.com/actions/virtual-environments/issues/785
       - name: Configure Windows Pagefile
-        uses: al-cheb/configure-pagefile-action@v1.5
+        uses: al-cheb/configure-pagefile-action@v1.4
       - name: Run tests
         run: mvn test -P prettierSkip,checkstyleSkip
 
@@ -108,7 +107,7 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         # this is necessary so that the correct credentials are put into the git configuration
         # when we push to dev-2.x and push the HTML to the git repo
         if: github.event_name == 'push' && (github.ref == 'refs/heads/dev-2.x' || github.ref == 'refs/heads/master')
@@ -118,7 +117,7 @@ jobs:
           # was modified last
           fetch-depth: 1000
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         # for a simple PR where we don't push, we don't need any credentials
         if: github.event_name != 'push'
 
@@ -130,7 +129,7 @@ jobs:
         if: github.event_name != 'push'
         run: mkdocs build
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
 
@@ -191,8 +190,8 @@ jobs:
     if: github.repository_owner == 'opentripplanner'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
       - name: Run code generator
@@ -216,7 +215,7 @@ jobs:
       - build-windows
       - build-linux
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up JDK 25
@@ -225,9 +224,9 @@ jobs:
           java-version: 25
           distribution: temurin
           cache: maven
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 18
       - name: Build container image with Jib, push to Dockerhub
         env:
           CONTAINER_REPO: docker.io/opentripplanner/opentripplanner

--- a/.github/workflows/close_stale_pr_and_issues.yml
+++ b/.github/workflows/close_stale_pr_and_issues.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.repository_owner == 'opentripplanner'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10.3.0
+      - uses: actions/stale@v6.0.1
         id: stale
         with:
           stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 30 days'

--- a/.github/workflows/debug-client.yml
+++ b/.github/workflows/debug-client.yml
@@ -31,19 +31,19 @@ jobs:
     steps:
       # this is necessary so that the correct credentials are put into the git configuration
       # when we push to dev-2.x and push the compiled output to the git repo
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         with:
           token: ${{ secrets.CHANGELOG_TOKEN }}
           fetch-depth: 0
 
       # for a simple PR where we don't push, we don't need any credentials
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 22
 
       - name: Set version
         run: echo "VERSION=`date +%Y/%m/%Y-%m-%dT%H:%M`" >> $GITHUB_ENV

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.repository_owner == 'opentripplanner' && contains( github.event.pull_request.labels.*.name, '+Integration Test' )
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
 
       - name: Set up JDK 25
         uses: actions/setup-java@v5

--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -66,7 +66,7 @@ jobs:
             profile: extended
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         if: matrix.profile == 'core' || github.ref == 'refs/heads/dev-2.x'
         with:
           fetch-depth: 0
@@ -81,7 +81,7 @@ jobs:
 
       - name: Set up Maven
         if: matrix.profile == 'core' || github.ref == 'refs/heads/dev-2.x'
-        uses: stCarolas/setup-maven@v5.1
+        uses: stCarolas/setup-maven@v5
         with:
           maven-version: 3.9.12
 
@@ -108,14 +108,14 @@ jobs:
 
       - name: Archive travel results file
         if: matrix.profile == 'core' || github.ref == 'refs/heads/dev-2.x'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.location }}-travelSearch-results.csv
           path: test/performance/${{ matrix.location }}/travelSearch-results-md.csv
 
       - name: Archive Flight Recorder instrumentation file
         if: matrix.profile == 'core' || github.ref == 'refs/heads/dev-2.x'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.location }}-flight-recorder
           path: ${{ matrix.location }}-speed-test.jfr

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.CHANGELOG_TOKEN }}
 
@@ -63,7 +63,7 @@ jobs:
           git config --global user.email 'serialization-version-bot@opentripplanner.org'
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.CHANGELOG_TOKEN }}
 


### PR DESCRIPTION
**Release-blocker hotfix.** PR #43 broke the Entur release process — `git merge entur/main_config` fails with a conflict in `.github/workflows/cibuild.yml`.

## Root cause
The release process resets `main` to `otp/dev-2.x`, merges the labeled PRs, then merges `main_config` on top. The workflows `cibuild`, `close_stale_pr_and_issues`, `debug-client`, `integration-test`, `performance-test`, `post-merge` are **inherited from upstream** and `dev-2.x` already bumped their action versions. By bumping the same lines in `main_config`, #43 created competing edits on lines `dev-2.x` also changed — directly adjacent to the Entur-only `setup-node` step in the `container-image` job — which the 3-way merge cannot auto-resolve.

Verified: pre-#43 `main_config` merges onto `dev-2.x` cleanly; post-#43 conflicts. After this revert, the merge is clean again.

## Fix
Revert #43's edits to the **six shared** workflow files back to the release-mergeable state. These files receive their action-version updates from `dev-2.x` automatically during release, so the bumps were redundant.

**Kept** (Entur-only — no upstream source, cannot come from a `dev-2.x` merge):
- `entur-a-otp-release.yml` — checkout v6, setup-python v6, setup-java v5, cache v5
- `entur-b-docker-build.yml` — checkout v6, setup-java v5, cache v5, upload-artifact v7
- `schema-validation.yml` — checkout v6, setup-node v6, node 24

## Takeaway
Action-version bumps for the shared workflows should be made upstream in `dev-2.x`, not in `main_config`. Only the Entur-only workflows should be bumped here.